### PR TITLE
Fix the warning

### DIFF
--- a/backend/common.h
+++ b/backend/common.h
@@ -41,9 +41,7 @@
 #  include <malloc.h>
 #  define z_alloca(nmemb) _alloca(nmemb)
 #else
-#  if !defined(__STDC_VERSION__) || __STDC_VERSION__ < 199000L /* C89 */
-#    include <alloca.h>
-#  endif
+#  include <alloca.h>
 #  define z_alloca(nmemb) alloca(nmemb)
 #endif
 

--- a/backend/rss.c
+++ b/backend/rss.c
@@ -745,7 +745,7 @@ INTERNAL int dbar_ltd_cc(struct zint_symbol *symbol, unsigned char source[], int
     checksum = 0;
     /* Calculate the checksum */
     for (i = 0; i < 14; i++) {
-#if _MSC_VER == 1900 && defined(_WIN64) /* MSVC 2015 x64 */
+#if defined(_MSC_VER) && _MSC_VER == 1900 && defined(_WIN64) /* MSVC 2015 x64 */
         checksum %= 89; /* Hack to get around optimizer bug */
 #endif
         checksum += checksum_weight_ltd[i] * left_widths[i];


### PR DESCRIPTION
- fix warning: implicit declaration of function 'alloca' 
- fix warning: "_MSC_VER" is not defined, evaluates to 0 [-Wundef]