### PR TITLE
Update zint-qt.desktop

### DIFF
--- a/zint-qt.desktop
+++ b/zint-qt.desktop
@@ -6,6 +6,7 @@ GenericName=Barcode Generator
 Comment=GUI for the creation of barcodes
 Exec=zint-qt
 Icon=zint-qt
+StartupWMClass=uk.org.zint.zint-qt
 Terminal=false
 Type=Application
 Categories=Graphics;2DGraphics;


### PR DESCRIPTION
Added the StartupWMClass definition: to show icon in dash on gnome.

Also, the generated Makefile does not include the .desktop file as aprt of installation.