### PR TITLE
Fix installation of cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,4 +201,4 @@ if(ZINT_UNINSTALL)
 endif()
 
 configure_file("zint-config.cmake.in" "zint-config.cmake" @ONLY)
-install(FILES "${CMAKE_CURRENT_BINARY_DIR}/zint-config.cmake" DESTINATION "${CMAKE_INSTALL_DATADIR}/zint")
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/zint-config.cmake" DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/zint")

--- a/backend/CMakeLists.txt
+++ b/backend/CMakeLists.txt
@@ -131,7 +131,7 @@ endif()
 if(ZINT_STATIC)
     install(TARGETS zint-static EXPORT zint-targets ${INSTALL_TARGETS_DEFAULT_ARGS})
 endif()
-install(EXPORT zint-targets NAMESPACE zint:: DESTINATION "${CMAKE_INSTALL_DATADIR}/zint")
+install(EXPORT zint-targets NAMESPACE zint:: DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/zint")
 install(FILES zint.h DESTINATION ${CMAKE_INSTALL_INCLUDEDIR} COMPONENT Devel)
 
 if(ZINT_TEST)


### PR DESCRIPTION
When binaries, libs and development files like include or cmake files are installed to different target directories then those where before relatively installed to the binary and not in the correct directory where other development related files where installed.

Tested inside of nixpkgs with zxing using the system library of zint.